### PR TITLE
fix: always use magic-string's insertLeft to insert code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,7 @@ export default function addVariableDeclarations(
       } else {
         let firstStatement = getFirstStatementInBlock(path.parentPath.scope.block);
         if (firstStatement) {
-          editor.insertRight(
+          editor.insertLeft(
             firstStatement.start,
             buildDeclarationForNames(
               newIdentifiers.map(({ name }) => name),
@@ -187,7 +187,7 @@ export default function addVariableDeclarations(
     }
   }
 
-  deferredInlinePositions.forEach(position => editor.insertRight(position, 'var '));
+  deferredInlinePositions.forEach(position => editor.insertLeft(position, 'var '));
 
   return {
     code: editor.toString(),

--- a/test/fixtures/for-of-with-separately-declared-variable/config.js
+++ b/test/fixtures/for-of-with-separately-declared-variable/config.js
@@ -1,0 +1,1 @@
+export const description = 'creates variable declaration with a destructured for-of partly already declared';

--- a/test/fixtures/for-of-with-separately-declared-variable/expected.js
+++ b/test/fixtures/for-of-with-separately-declared-variable/expected.js
@@ -1,0 +1,5 @@
+var b;
+var a = null;
+for ({a, b} of c) {
+  continue;
+};

--- a/test/fixtures/for-of-with-separately-declared-variable/input.js
+++ b/test/fixtures/for-of-with-separately-declared-variable/input.js
@@ -1,0 +1,4 @@
+a = null;
+for ({a, b} of c) {
+  continue;
+};


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/521

The `insertRight` function in magic-string has the weird property that repeated
inserts at the same index show up in reverse order in the resulting string,
which caused a bug where a `var` was inserted on the wrong line. While there may
be a way to make `insertRight` work, the simpler approach seems to be to do the
same thing as decaffeinate: always use `insertLeft`, and try to do insert
operations in order.

In testing this, I also made sure that all decaffeinate tests pass with this
change applied.