### PR TITLE
fix: configure babylon to allow top-level returns

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,11 @@ const BABYLON_PLUGINS = [
 export default function addVariableDeclarations(
   source: string,
   editor: MagicString=new MagicString(source),
-  ast: Node=parse(source, { plugins: BABYLON_PLUGINS, sourceType: 'module' })
+  ast: Node=parse(source, {
+      plugins: BABYLON_PLUGINS,
+      sourceType: 'module',
+      allowReturnOutsideFunction: true
+    })
 ): { code: string, map: SourceMap } {
   let state = null;
   let seen = new Set();

--- a/test/fixtures/allow-top-level-return/config.js
+++ b/test/fixtures/allow-top-level-return/config.js
@@ -1,0 +1,1 @@
+export const description = 'allows code that does a top-level return';

--- a/test/fixtures/allow-top-level-return/expected.js
+++ b/test/fixtures/allow-top-level-return/expected.js
@@ -1,0 +1,1 @@
+return a;

--- a/test/fixtures/allow-top-level-return/input.js
+++ b/test/fixtures/allow-top-level-return/input.js
@@ -1,0 +1,1 @@
+return a;


### PR DESCRIPTION
Progress toward https://github.com/decaffeinate/decaffeinate/issues/654