### PR TITLE
refactor: use `@codemod/parser` rather than `@babel/parser`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "typescript": "^3.3.3"
   },
   "dependencies": {
-    "@babel/parser": "^7.5.5",
     "@babel/traverse": "^7.5.5",
     "@babel/types": "^7.5.5",
+    "@codemod/parser": "^1.0.1",
     "@types/babel__traverse": "^7.0.7",
     "magic-string": "^0.25.3"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import getBindingIdentifiersFromLHS from './utils/getBindingIdentifiersFromLHS';
 import lhsHasNonIdentifierAssignment from './utils/lhsHasNonIdentifierAssignment';
 import traverse, { NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
-import { parse, ParserPlugin, ParserOptions } from '@babel/parser';
+import { parse } from '@codemod/parser';
 
 // Extracted from magic-string/index.d.ts.
 export type SourceMap = {
@@ -15,27 +15,7 @@ export type SourceMap = {
 export default function addVariableDeclarations(
   source: string,
   editor = new MagicString(source),
-  ast: t.File = parse(source, {
-    plugins: [
-      'jsx',
-      'flow',
-      'doExpressions',
-      'objectRestSpread',
-      ['decorators', { decoratorsBeforeExport: true }],
-      'classProperties',
-      'asyncGenerators',
-      'functionBind',
-      'functionSent',
-      'dynamicImport',
-      'optionalChaining',
-    ] as Array<ParserPlugin>,
-    sourceType: 'module',
-    allowReturnOutsideFunction: true,
-    // TODO: remove this `keyof` hack once `allowUndeclaredExports` is included in typings
-    // https://github.com/babel/babel/pull/10263
-    ['allowUndeclaredExports' as keyof ParserOptions]: true,
-    tokens: true,
-  })
+  ast: t.File = parse(source, { tokens: true })
 ): { code: string, map: SourceMap } {
   let state: TraverseState | null = null;
   let savedStates: Array<TraverseState> = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,6 +139,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@codemod/parser@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@codemod/parser/-/parser-1.0.1.tgz#6f52ac964834a08775419e44b76440a4d6b422ee"
+  integrity sha512-5FNjeWCknk5i+wXSKYtau6yt/N81CvHLU/7YDKH+bLsrCsArLu9Jt9nRDs+L2fpWziYm/IFdHDpCQld2Kft6NQ==
+  dependencies:
+    "@babel/parser" "^7.5.5"
+
 "@jest/console@^24.7.1":
   version "24.7.1"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.7.1.tgz#32a9e42535a97aedfe037e725bd67e954b459545"
@@ -343,17 +350,17 @@
   resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
   integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
 
-"@types/jest@^24.0.5":
-  version "24.0.15"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.15.tgz#6c42d5af7fe3b44ffff7cc65de7bf741e8fa427f"
-  integrity sha512-MU1HIvWUme74stAoc3mgAi+aMlgKOudgEvQDIm1v4RkrDudBh1T+NFp5sftpBAdXdx1J0PbdpJ+M2EsSOi1djA==
+"@types/jest@^24.0.16":
+  version "24.0.17"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.17.tgz#b66ea026efb746eb5db1356ee28518aaff7af416"
+  integrity sha512-1cy3xkOAfSYn78dsBWy4M3h/QF/HeWPchNFDjysVtp3GHeTdSmtluNnELfCmfNRRHo0OWEcpf+NsEJQvwQfdqQ==
   dependencies:
     "@types/jest-diff" "*"
 
-"@types/node@^12.6.6":
-  version "12.6.8"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"
-  integrity sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==
+"@types/node@^12.7.1":
+  version "12.7.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.1.tgz#3b5c3a26393c19b400844ac422bd0f631a94d69d"
+  integrity sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
This outsources the "enable all the syntax" options to `@babel/parser` that were previously hardcoded in this package.