### PR TITLE
refactor: use named exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ npm install add-variable-declarations
 ## Usage
 
 ```js
-import addVariableDeclarations from 'add-variable-declarations';
+import { addVariableDeclarations } from 'add-variable-declarations';
 
 const source = `
 PI = 3.14;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export type SourceMap = {
   toUrl(): string;
 };
 
-export default function addVariableDeclarations(
+export function addVariableDeclarations(
   source: string,
   editor = new MagicString(source),
   ast: t.File = parse(source, { tokens: true })

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
-import refactor from '../src/index';
+import { addVariableDeclarations } from '../src/index';
 
 readdirSync(join(__dirname, 'fixtures')).forEach(testFixture);
 
@@ -10,7 +10,7 @@ function testFixture(name: string) {
     config.description,
     () => {
       expect(
-        refactor(readFixtureFile(name, 'input.js')).code
+        addVariableDeclarations(readFixtureFile(name, 'input.js')).code
       ).toMatchSnapshot();
     }
   );


### PR DESCRIPTION
BREAKING CHANGE: Instead of a default export, we now use a named export called `addVariableDeclarations`.